### PR TITLE
do not trigger release on schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,4 @@
 on:
-  schedule:
-    - cron: "0 0 * * 0"
   workflow_dispatch:
 
 name: Create Release


### PR DESCRIPTION
Removing nightly cron job that triggers the release pipeline in regards to @bpholt 's comment [here](https://github.com/Dwolla/jenkins-agent-docker-sonar-scanner/pull/15#issuecomment-1132075371).